### PR TITLE
Add search, categories and service pages

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,3 +1,6 @@
+html {
+    scroll-behavior: smooth;
+}
 @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap');
 
 body {
@@ -66,4 +69,15 @@ footer {
     .navbar-nav .nav-link {
         padding: 0.5rem 1rem;
     }
+}
+.category-btn.active {
+    background-color: #3391ff;
+    color: #fff;
+}
+.btn {
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 0.5rem 1rem rgba(0,0,0,0.15);
 }

--- a/data/services.json
+++ b/data/services.json
@@ -1,22 +1,34 @@
 [
   {
+    "id": "abc-tailors",
     "name": "ABC Tailors",
     "city": "Colombo",
-    "phone": "0771234567"
+    "phone": "0771234567",
+    "category": "tailor",
+    "description": "Professional tailoring services."
   },
   {
+    "id": "xyz-electricians",
     "name": "XYZ Electricians",
     "city": "Kandy",
-    "phone": "0719876543"
+    "phone": "0719876543",
+    "category": "electrician",
+    "description": "Qualified electricians for all jobs."
   },
   {
+    "id": "best-tutors",
     "name": "Best Tutors",
     "city": "Galle",
-    "phone": "0755555555"
+    "phone": "0755555555",
+    "category": "tutor",
+    "description": "Private tutoring for all subjects."
   },
   {
+    "id": "coolair-repairs",
     "name": "CoolAir Repairs",
     "city": "Negombo",
-    "phone": "0761111111"
+    "phone": "0761111111",
+    "category": "ac",
+    "description": "Expert AC repair services."
   }
 ]

--- a/index.html
+++ b/index.html
@@ -3,9 +3,15 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Discover trusted local services across Sri Lanka."
+    <meta property="og:title" content="WedaKiriya.lk - Find Local Services in Sri Lanka"/>
+    <meta property="og:description" content="Discover trusted local services across Sri Lanka."/>
+    <meta property="og:image" content="images/hero.svg"/>
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E%F0%9F%94%A7%3C/text%3E%3C/svg%3E">
     <title>WedaKiriya.lk - Find Local Services in Sri Lanka</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css">
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
@@ -34,44 +40,54 @@
         </section>
         <section class="services py-5 bg-light mt-4">
             <div class="container">
+                <input type="text" id="searchInput" class="form-control mb-3" placeholder="Search by service or city">
+                <div class="mb-3">
+                    <div class="btn-group" role="group" aria-label="Filter">
+                        <button class="btn btn-outline-secondary btn-sm category-btn active" data-filter="all">All</button>
+                        <button class="btn btn-outline-secondary btn-sm category-btn" data-filter="tailor">Tailor</button>
+                        <button class="btn btn-outline-secondary btn-sm category-btn" data-filter="electrician">Electrician</button>
+                        <button class="btn btn-outline-secondary btn-sm category-btn" data-filter="tutor">Tutor</button>
+                        <button class="btn btn-outline-secondary btn-sm category-btn" data-filter="ac">AC Repair</button>
+                    </div>
+                </div>
                 <div class="row g-4">
                     <div class="col-12 col-sm-6 col-lg-3">
-                        <div class="card h-100 service-card">
+                        <div class="card h-100 service-card" data-aos="fade-up" data-name="abc tailors" data-city="colombo" data-category="tailor" data-id="abc-tailors">
                             <img src="images/tailor.svg" class="card-img-top" alt="Tailor">
                             <div class="card-body">
                                 <h5 class="card-title">ABC Tailors</h5>
                                 <p class="card-text">Colombo</p>
-                                <p class="card-text">0771234567</p>
+                                <a href="https://wa.me/94771234567" target="_blank" class="btn btn-success btn-sm mb-2">WhatsApp Now</a><br><a href="service.html?id=abc-tailors" class="btn btn-primary btn-sm">View Details</a>
                             </div>
                         </div>
                     </div>
                     <div class="col-12 col-sm-6 col-lg-3">
-                        <div class="card h-100 service-card">
+                        <div class="card h-100 service-card" data-aos="fade-up" data-name="xyz electricians" data-city="kandy" data-category="electrician" data-id="xyz-electricians">
                             <img src="images/electrician.svg" class="card-img-top" alt="Electrician">
                             <div class="card-body">
                                 <h5 class="card-title">XYZ Electricians</h5>
                                 <p class="card-text">Kandy</p>
-                                <p class="card-text">0719876543</p>
+                                <a href="https://wa.me/94719876543" target="_blank" class="btn btn-success btn-sm mb-2">WhatsApp Now</a><br><a href="service.html?id=xyz-electricians" class="btn btn-primary btn-sm">View Details</a>
                             </div>
                         </div>
                     </div>
                     <div class="col-12 col-sm-6 col-lg-3">
-                        <div class="card h-100 service-card">
+                        <div class="card h-100 service-card" data-aos="fade-up" data-name="best tutors" data-city="galle" data-category="tutor" data-id="best-tutors">
                             <img src="images/tutor.svg" class="card-img-top" alt="Tutor">
                             <div class="card-body">
                                 <h5 class="card-title">Best Tutors</h5>
                                 <p class="card-text">Galle</p>
-                                <p class="card-text">0755555555</p>
+                                <a href="https://wa.me/94755555555" target="_blank" class="btn btn-success btn-sm mb-2">WhatsApp Now</a><br><a href="service.html?id=best-tutors" class="btn btn-primary btn-sm">View Details</a>
                             </div>
                         </div>
                     </div>
                     <div class="col-12 col-sm-6 col-lg-3">
-                        <div class="card h-100 service-card">
+                        <div class="card h-100 service-card" data-aos="fade-up" data-name="coolair repairs" data-city="negombo" data-category="ac" data-id="coolair-repairs">
                             <img src="images/ac_repair.svg" class="card-img-top" alt="AC Repair">
                             <div class="card-body">
                                 <h5 class="card-title">CoolAir Repairs</h5>
                                 <p class="card-text">Negombo</p>
-                                <p class="card-text">0761111111</p>
+                                <a href="https://wa.me/94761111111" target="_blank" class="btn btn-success btn-sm mb-2">WhatsApp Now</a><br><a href="service.html?id=coolair-repairs" class="btn btn-primary btn-sm">View Details</a>
                             </div>
                         </div>
                     </div>
@@ -91,5 +107,7 @@
         </div>
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.js"></script>
+    <script src="js/main.js"></script>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,32 @@
+// filtering and animations
+AOS.init();
+const searchInput = document.getElementById('searchInput');
+const categoryButtons = document.querySelectorAll('.category-btn');
+
+function filterCards() {
+  const q = searchInput ? searchInput.value.toLowerCase() : '';
+  const activeBtn = document.querySelector('.category-btn.active');
+  const catFilter = activeBtn ? activeBtn.dataset.filter : 'all';
+
+  document.querySelectorAll('.service-card').forEach(card => {
+    const name = card.dataset.name;
+    const city = card.dataset.city;
+    const cat = card.dataset.category;
+    const matchesSearch = name.includes(q) || city.includes(q);
+    const matchesCat = catFilter === 'all' || cat === catFilter;
+    card.parentElement.style.display = matchesSearch && matchesCat ? '' : 'none';
+  });
+}
+
+if (searchInput) {
+  searchInput.addEventListener('input', filterCards);
+}
+
+categoryButtons.forEach(btn => {
+  btn.addEventListener('click', () => {
+    categoryButtons.forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+    filterCards();
+  });
+});
+

--- a/service.html
+++ b/service.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Service details on WedaKiriya.lk">
+    <meta property="og:title" content="Service Details">
+    <meta property="og:description" content="Local service information">
+    <meta property="og:image" content="images/hero.svg">
+    <title>Service Details - WedaKiriya.lk</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css">
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E%F0%9F%94%A7%3C/text%3E%3C/svg%3E">
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary fixed-top">
+        <div class="container">
+            <a class="navbar-brand fw-bold" href="index.html">WedaKiriya.lk</a>
+        </div>
+    </nav>
+    <main class="py-5 mt-4">
+        <div class="container" id="service-details">
+            Loading...
+        </div>
+    </main>
+    <footer class="bg-primary text-white text-center py-3 mt-5">
+        <div class="container">
+            <p class="mb-0">&copy; 2024 WedaKiriya.lk</p>
+        </div>
+    </footer>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.js"></script>
+    <script>
+    AOS.init();
+    const params = new URLSearchParams(window.location.search);
+    const id = params.get('id');
+    const container = document.getElementById('service-details');
+    fetch('data/services.json')
+        .then(r => r.json())
+        .then(list => {
+            const s = list.find(item => item.id === id);
+            if (!s) throw new Error('not found');
+            document.title = `${s.name} - WedaKiriya.lk`;
+            container.innerHTML = `
+                <h1 class="mb-3" data-aos="fade-down">${s.name}</h1>
+                <p class="text-muted" data-aos="fade-down">${s.city}</p>
+                <a href="https://wa.me/94${s.phone.substring(1)}" target="_blank" class="btn btn-success mb-3" data-aos="fade-up">WhatsApp Now</a>
+                <p data-aos="fade-up">${s.description}</p>
+                <iframe data-aos="fade-up" src="https://www.google.com/maps?q=${encodeURIComponent(s.city)}&output=embed" width="100%" height="300" style="border:0;" allowfullscreen loading="lazy"></iframe>
+                <form class="mt-4" data-aos="fade-up">
+                    <div class="mb-3"><input type="text" class="form-control" placeholder="Your Name"></div>
+                    <div class="mb-3"><input type="email" class="form-control" placeholder="Your Email"></div>
+                    <div class="mb-3"><textarea class="form-control" rows="4" placeholder="Message"></textarea></div>
+                    <button type="submit" class="btn btn-primary">Send</button>
+                </form>`;
+        })
+        .catch(() => {
+            container.textContent = 'Service not found.';
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add site favicon and basic meta tags
- enable smooth scrolling and button hover effects
- add search bar and category filters for services
- show WhatsApp links and view details button on each service
- add a dynamic service details page with simple map and contact form
- refine filtering logic and load service details from json
- remove binary favicon files and embed favicon via data URI

## Testing
- `python3 -m json.tool data/services.json`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68472be65a54832397cad91e8c26b634