### PR TITLE
Refine hero heading style

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -23,8 +23,9 @@ body {
     display: flex;
     align-items: center;
     justify-content: center;
-    min-height: 50vh;
-    margin-bottom: 2rem;
+    padding: 60px 0 40px;
+    min-height: 40vh;
+    margin-bottom: 1.5rem;
 }
 
 .hero::after {
@@ -49,6 +50,17 @@ body {
     inset: 0;
     background: rgba(0, 0, 0, 0.4);
     z-index: 0;
+}
+
+.hero-title {
+    font-size: 2.25rem;
+    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+}
+
+@media (max-width: 576px) {
+    .hero-title {
+        font-size: 1.5rem;
+    }
 }
 
 .service-card {
@@ -93,7 +105,8 @@ footer {
         padding: 0.5rem 1rem;
     }
     .hero {
-        padding-top: 3rem;
+        padding: 40px 0 20px;
+        min-height: 30vh;
     }
 }
 .category-btn.active {

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
         <section class="hero d-flex align-items-center text-center" aria-label="Hero">
             <div class="overlay"></div>
             <div class="container position-relative">
-                <h1 class="display-4 fw-bold text-white" data-aos="fade-down">Find the Best Local Services Near You</h1>
+                <h1 class="hero-title fw-semibold text-white" data-aos="fade-down">Find the Best Local Services Near You</h1>
             </div>
         </section>
         <section class="services py-5 bg-light mt-4">


### PR DESCRIPTION
## Summary
- downsize hero headline text
- add `hero-title` styles with responsive sizing and shadow
- adjust hero padding for smaller vertical space

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68474e330284832385e0e400af6c4997