### PR TITLE
Add admin dashboard with management features

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -28,6 +28,25 @@
       <button id="fetchCategories" class="bg-blue-600 text-white px-3 py-1 rounded">Import Categories</button>
       <ul id="catList" class="mt-4"></ul>
     </div>
+    <div id="dashboard" class="mt-4"></div>
+    <div id="businessManager" class="mt-4">
+      <h2 class="text-lg font-semibold mb-2">Manage Businesses</h2>
+      <form id="bizForm" class="space-y-2 mb-4">
+        <input type="hidden" name="index" value="">
+        <input type="text" name="name" placeholder="Name" class="w-full p-1 border rounded" required>
+        <input type="text" name="city" placeholder="City" class="w-full p-1 border rounded" required>
+        <input type="text" name="phone" placeholder="Phone" class="w-full p-1 border rounded" required>
+        <input type="text" name="category" placeholder="Category" class="w-full p-1 border rounded" required>
+        <textarea name="description" placeholder="Description" class="w-full p-1 border rounded"></textarea>
+        <label class="block"><input type="checkbox" name="featured"> Featured</label>
+        <button type="submit" class="bg-blue-600 text-white px-3 py-1 rounded">Save</button>
+        <button type="button" id="cancelEdit" class="hidden px-3 py-1 border rounded">Cancel</button>
+      </form>
+      <table class="min-w-full border text-sm">
+        <thead><tr class="bg-gray-200"><th class="border px-1">Name</th><th class="border px-1">City</th><th class="border px-1">Category</th><th class="border px-1">Actions</th></tr></thead>
+        <tbody id="bizTableBody"></tbody>
+      </table>
+    </div>
   </section>
 </main>
 <script type="module" src="js/admin.js"></script>

--- a/data/services.js
+++ b/data/services.js
@@ -7,7 +7,7 @@ window.servicesData = [
     category: "tailor",
     description: "Professional tailoring services.",
     featured: true
-  },,,,
+  },
   {
     id: "xyz-electricians",
     name: "XYZ Electricians",
@@ -108,3 +108,10 @@ window.servicesData = [
     featured: false
   }
 ];
+
+try {
+  const stored = JSON.parse(localStorage.getItem('services'));
+  if (Array.isArray(stored)) {
+    window.servicesData = stored;
+  }
+} catch {}

--- a/js/admin.js
+++ b/js/admin.js
@@ -2,6 +2,13 @@ const PASSWORD = 'wedakiriya';
 const loginForm = document.getElementById('loginForm');
 const sections = document.getElementById('adminSections');
 const logoutBtn = document.getElementById('logoutBtn');
+const dash = document.getElementById('dashboard');
+const bizTableBody = document.getElementById('bizTableBody');
+const bizForm = document.getElementById('bizForm');
+const cancelBtn = document.getElementById('cancelEdit');
+
+const defaultServices = window.servicesData || [];
+let services = [];
 
 function checkAuth() {
   if (localStorage.getItem('adminAuth')) showAdmin();
@@ -22,26 +29,139 @@ logoutBtn.addEventListener('click', () => {
   location.reload();
 });
 
+function loadServices() {
+  try {
+    const stored = JSON.parse(localStorage.getItem('services'));
+    services = Array.isArray(stored) ? stored : defaultServices.slice();
+  } catch {
+    services = defaultServices.slice();
+  }
+}
+
+function saveServices() {
+  localStorage.setItem('services', JSON.stringify(services));
+}
+
+function renderDashboard() {
+  if (!dash) return;
+  const cities = new Set(services.map(s => s.city));
+  const cats = new Set(services.map(s => s.category));
+  dash.innerHTML = `
+    <p>Total listings: ${services.length}</p>
+    <p>Categories: ${cats.size}</p>
+    <p>Cities covered: ${cities.size}</p>
+  `;
+}
+
+function renderTable() {
+  if (!bizTableBody) return;
+  bizTableBody.innerHTML = services
+    .map((s, i) => `
+      <tr>
+        <td class="border px-1">${s.name}</td>
+        <td class="border px-1">${s.city}</td>
+        <td class="border px-1">${s.category}</td>
+        <td class="border px-1 text-center">
+          <button data-index="${i}" class="editBtn text-blue-600">Edit</button>
+          <button data-index="${i}" class="delBtn text-red-600 ml-2">Delete</button>
+        </td>
+      </tr>`)
+    .join('');
+}
+
 function showAdmin() {
   loginForm.classList.add('hidden');
   sections.classList.remove('hidden');
   logoutBtn.classList.remove('hidden');
+  loadServices();
+  const cities = JSON.parse(localStorage.getItem('cities') || '[]');
+  const cityList = document.getElementById('cityList');
+  if (cityList && cities.length) cityList.innerHTML = cities.map(c => `<li>${c}</li>`).join('');
+  const categories = JSON.parse(localStorage.getItem('categories') || '[]');
+  const catList = document.getElementById('catList');
+  if (catList && categories.length) catList.innerHTML = categories.map(c => `<li>${c}</li>`).join('');
+  renderTable();
+  renderDashboard();
 }
 
 async function fetchCities() {
   const res = await fetch('https://countriesnow.space/api/v0.1/countries/cities/q?country=Sri%20Lanka');
   const data = await res.json();
   const list = document.getElementById('cityList');
+  localStorage.setItem('cities', JSON.stringify(data.data));
   list.innerHTML = data.data.map(c => `<li>${c}</li>`).join('');
+  renderDashboard();
 }
 
 async function fetchCategories() {
-  const categories = ['Tailor','Electrician','Tutor','AC Repair'];
+  const res = await fetch('https://raw.githubusercontent.com/dariusk/corpora/master/data/humans/occupations.json');
+  const data = await res.json();
+  const categories = data.occupations.slice(0, 20);
+  localStorage.setItem('categories', JSON.stringify(categories));
   const list = document.getElementById('catList');
   list.innerHTML = categories.map(c => `<li>${c}</li>`).join('');
+  renderDashboard();
 }
 
 document.getElementById('fetchCities').addEventListener('click', fetchCities);
 document.getElementById('fetchCategories').addEventListener('click', fetchCategories);
+
+if (bizForm) {
+  bizForm.addEventListener('submit', e => {
+    e.preventDefault();
+    const form = e.target;
+    const idx = form.index.value;
+    const entry = {
+      id: form.name.value.toLowerCase().replace(/\s+/g, '-'),
+      name: form.name.value,
+      city: form.city.value,
+      phone: form.phone.value,
+      category: form.category.value,
+      description: form.description.value,
+      featured: form.featured.checked
+    };
+    if (idx === '') {
+      services.push(entry);
+    } else {
+      services[idx] = entry;
+    }
+    saveServices();
+    renderTable();
+    renderDashboard();
+    form.reset();
+    form.index.value = '';
+    cancelBtn.classList.add('hidden');
+  });
+}
+
+if (cancelBtn) {
+  cancelBtn.addEventListener('click', () => {
+    bizForm.reset();
+    bizForm.index.value = '';
+    cancelBtn.classList.add('hidden');
+  });
+}
+
+if (bizTableBody) {
+  bizTableBody.addEventListener('click', e => {
+    const idx = e.target.dataset.index;
+    if (e.target.classList.contains('editBtn')) {
+      const b = services[idx];
+      bizForm.name.value = b.name;
+      bizForm.city.value = b.city;
+      bizForm.phone.value = b.phone;
+      bizForm.category.value = b.category;
+      bizForm.description.value = b.description;
+      bizForm.featured.checked = b.featured;
+      bizForm.index.value = idx;
+      cancelBtn.classList.remove('hidden');
+    } else if (e.target.classList.contains('delBtn')) {
+      services.splice(idx, 1);
+      saveServices();
+      renderTable();
+      renderDashboard();
+    }
+  });
+}
 
 checkAuth();


### PR DESCRIPTION
## Summary
- expand admin page with dashboard and business management
- fetch city data and categories from public APIs and store in localStorage
- allow adding, editing and removing businesses
- persist business listings in localStorage and load them on the site

## Testing
- `npm test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684ea596e5c48323b765765b27664c16