### PR TITLE
Fix admin instructions and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The repository now ships with small SVG icons, so it works offline without exter
      "SUPABASE_ANON_KEY": "your-anon-key"
    }
    ```
-5. Sign up at least one user using `admin.html` and mark that user as an admin by ensuring the `is_admin` column in the `users` table is `true`.
+5. Sign up at least one user using `admin.html`. The SQL script adds the first registered user to the `admin_users` table so they can access the admin panel. Additional admins can be inserted into this table manually. If you receive a `404` response from `/rest/v1/admin_users`, verify this table exists in your project.
 
 ## Deploying to GitHub Pages
 1. Push the repository to your GitHub account.

--- a/js/admin.js
+++ b/js/admin.js
@@ -43,8 +43,23 @@ loginForm.addEventListener('submit', async (e) => {
 
 async function checkAdmin() {
   const user = (await supabase.auth.getUser()).data.user;
-  const { data } = await supabase.from('admin_users').select('id').eq('user_id', user.id).single();
-  if (!data) { alert('Not an admin user'); await supabase.auth.signOut(); return; }
+  const { data, error } = await supabase
+    .from('admin_users')
+    .select('id')
+    .eq('user_id', user.id)
+    .single();
+  if (error) {
+    alert(
+      `${error.message}\nCheck that the admin_users table exists and that your account is listed as an admin.`
+    );
+    await supabase.auth.signOut();
+    return;
+  }
+  if (!data) {
+    alert('Not an admin user');
+    await supabase.auth.signOut();
+    return;
+  }
   loginBox.style.display = 'none';
   panel.style.display = 'block';
   loadLists();


### PR DESCRIPTION
## Summary
- clarify admin setup in README
- handle Supabase errors when verifying admin

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684eae2cc59083239d33a15963bec251