### PR TITLE
Add language persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,4 @@ The repository now ships with small SVG icons, so it works offline without exter
 - Users can favourite listings on the homepage. Favourites are stored in the `favorites` table.
 - Listings can be reported from the details page which inserts a row into the `reports` table.
 - Additional SQL script `sql/extended_schema.sql` creates tables for listings, images, favourites and reports.
+- Sinhala/English language switcher with localStorage and URL parameter persistence.

--- a/js/translations.js
+++ b/js/translations.js
@@ -113,7 +113,12 @@ window.translations = {
   }
 };
 
-window.currentLang = localStorage.getItem('lang') || 'en';
+const urlParams = new URLSearchParams(window.location.search);
+const paramLang = urlParams.get('lang');
+window.currentLang = paramLang || localStorage.getItem('lang') || 'en';
+if (paramLang) {
+  localStorage.setItem('lang', paramLang);
+}
 
 window.t = function (key) {
   const lang = window.currentLang;
@@ -141,6 +146,10 @@ document.addEventListener('DOMContentLoaded', () => {
     toggle.addEventListener('change', () => {
       window.currentLang = toggle.value;
       localStorage.setItem('lang', window.currentLang);
+      const params = new URLSearchParams(window.location.search);
+      params.set('lang', window.currentLang);
+      const newUrl = window.location.pathname + '?' + params.toString();
+      history.replaceState(null, '', newUrl);
       applyTranslations();
     });
   }


### PR DESCRIPTION
## Summary
- persist language from URL parameter or localStorage
- update URL when switching languages
- document language switcher feature in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684ee0a2bd708323826afb560e63a0ed