### PR TITLE
Add admin analytics dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,4 +63,5 @@ The repository now ships with small SVG icons, so it works offline without exter
 - Listings now support comments. Users can post comments on a listing and report inappropriate ones, stored in `comments` and `comment_reports` tables.
 =======
 - `dashboard.html` shows a simple user dashboard where logged in users can view and remove their favourites and logout.
+- `admin-dashboard.html` offers analytics charts and a moderation table for reported listings. It requires an admin account from the `admin_users` table. The updated `sql/extended_schema.sql` script adds `category` and `is_active` columns to `listings` and a `status` column to `reports` for this dashboard.
 

--- a/admin-dashboard.html
+++ b/admin-dashboard.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Admin Dashboard</title>
+  <link rel="stylesheet" href="css/admin.css">
+  <link rel="stylesheet" href="css/admin-dashboard.css">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+<div id="login" class="login">
+  <h2>Admin Login</h2>
+  <form id="loginForm">
+    <input type="email" name="email" placeholder="Email" required>
+    <input type="password" name="password" placeholder="Password" required>
+    <button type="submit">Login</button>
+  </form>
+</div>
+<div id="dashboard">
+  <button id="logoutBtn" class="mb-4">Logout</button>
+  <h2>Admin Analytics</h2>
+  <div class="stats">
+    <div id="stat-listings"></div>
+    <div id="stat-users"></div>
+    <div id="stat-reports"></div>
+    <div id="stat-active-listings"></div>
+    <div id="stat-new-listings"></div>
+  </div>
+  <canvas id="categoryChart" height="200"></canvas>
+  <canvas id="locationChart" height="200"></canvas>
+
+  <h2>Moderation</h2>
+  <table id="moderation-table">
+    <thead>
+      <tr>
+        <th>Title</th>
+        <th>Reporter</th>
+        <th>Reason</th>
+        <th>Date</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+</div>
+<script type="module" src="js/adminDashboard.js"></script>
+</body>
+</html>

--- a/css/admin-dashboard.css
+++ b/css/admin-dashboard.css
@@ -1,0 +1,7 @@
+#dashboard { display:none; max-width:1000px; margin:20px auto; }
+.stats { display:flex; flex-wrap:wrap; gap:1rem; margin-bottom:1rem; }
+.stats div { background:#fff; border:1px solid #ddd; border-radius:4px; padding:10px; flex:1 1 150px; text-align:center; }
+#moderation-table { width:100%; border-collapse:collapse; }
+#moderation-table th, #moderation-table td { border:1px solid #ddd; padding:6px; }
+#moderation-table button { margin-right:4px; }
+@media (max-width:600px){ .stats { flex-direction:column; } }

--- a/js/adminDashboard.js
+++ b/js/adminDashboard.js
@@ -1,0 +1,127 @@
+import { getSupabase } from './supabaseClient.js';
+
+let supabase;
+const loginBox = document.getElementById('login');
+const loginForm = document.getElementById('loginForm');
+const dash = document.getElementById('dashboard');
+const logoutBtn = document.getElementById('logoutBtn');
+
+init();
+
+async function init(){
+  supabase = await getSupabase();
+  const { data:{ session } } = await supabase.auth.getSession();
+  if(session) await checkAdmin();
+}
+
+loginForm.addEventListener('submit', async e => {
+  e.preventDefault();
+  const email = e.target.email.value;
+  const password = e.target.password.value;
+  const { error } = await supabase.auth.signInWithPassword({ email, password });
+  if(error){ alert(error.message); return; }
+  await checkAdmin();
+});
+
+logoutBtn.addEventListener('click', async () => {
+  await supabase.auth.signOut();
+  location.reload();
+});
+
+async function checkAdmin(){
+  const { data:{ user } } = await supabase.auth.getUser();
+  if(!user) return;
+  const { data, error } = await supabase.from('admin_users').select('id').eq('user_id', user.id).single();
+  if(error || !data){
+    alert('Not an admin user');
+    await supabase.auth.signOut();
+    return;
+  }
+  loginBox.style.display = 'none';
+  dash.style.display = 'block';
+  await loadAnalytics();
+  await loadReports();
+}
+
+async function loadAnalytics(){
+  const [listingsRes, usersRes, reportsRes] = await Promise.all([
+    supabase.from('listings').select('id,category,location,is_active,created_at'),
+    supabase.from('users').select('id', { count:'exact', head:true }),
+    supabase.from('reports').select('id', { count:'exact', head:true })
+  ]);
+
+  const listings = listingsRes.data || [];
+  const totalListings = listings.length;
+  const activeListings = listings.filter(l=>l.is_active).length;
+  const now = new Date();
+  const week = new Date(now); week.setDate(now.getDate()-7);
+  const month = new Date(now); month.setMonth(now.getMonth()-1);
+  const weekCount = listings.filter(l=> new Date(l.created_at) >= week).length;
+  const monthCount = listings.filter(l=> new Date(l.created_at) >= month).length;
+
+  document.getElementById('stat-listings').textContent = `Total listings: ${totalListings}`;
+  document.getElementById('stat-users').textContent = `Total users: ${usersRes.count || 0}`;
+  document.getElementById('stat-reports').textContent = `Total reports: ${reportsRes.count || 0}`;
+  document.getElementById('stat-active-listings').textContent = `Active listings: ${activeListings}`;
+  document.getElementById('stat-new-listings').textContent = `New listings this week: ${weekCount} / month: ${monthCount}`;
+
+  const byCat = {};
+  const byLoc = {};
+  listings.forEach(l=>{
+    const c = l.category || 'Other';
+    const loc = l.location || 'Other';
+    byCat[c] = (byCat[c]||0)+1;
+    byLoc[loc] = (byLoc[loc]||0)+1;
+  });
+
+  new Chart(document.getElementById('categoryChart'), {
+    type:'pie',
+    data:{ labels:Object.keys(byCat), datasets:[{ data:Object.values(byCat) }] }
+  });
+
+  new Chart(document.getElementById('locationChart'), {
+    type:'bar',
+    data:{ labels:Object.keys(byLoc), datasets:[{ data:Object.values(byLoc), backgroundColor:'#2563eb' }] },
+    options:{ scales:{ y:{ beginAtZero:true } } }
+  });
+}
+
+async function loadReports(){
+  const { data } = await supabase.from('reports').select('*').eq('status','open').order('created_at',{ascending:false});
+  const tbody = document.querySelector('#moderation-table tbody');
+  tbody.innerHTML = '';
+  for(const r of data || []){
+    const { data: listing } = await supabase.from('listings').select('title').eq('id', r.listing_id).single();
+    const { data: user } = await supabase.from('users').select('email').eq('id', r.user_id).single();
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${listing ? listing.title : r.listing_id}</td>
+      <td>${user ? user.email : r.user_id}</td>
+      <td>${r.reason || ''}</td>
+      <td>${new Date(r.created_at).toLocaleDateString()}</td>
+      <td>
+        <button class="view" data-id="${r.listing_id}">View</button>
+        <button class="approve" data-id="${r.id}">Approve</button>
+        <button class="remove" data-id="${r.listing_id}">Remove</button>
+      </td>`;
+    tbody.appendChild(tr);
+  }
+}
+
+document.getElementById('moderation-table').addEventListener('click', async e => {
+  const id = e.target.dataset.id;
+  if(e.target.classList.contains('view')){
+    window.open(`service.html?id=${id}`,'_blank');
+  } else if(e.target.classList.contains('approve')){
+    if(confirm('Mark report as resolved?')){
+      await supabase.from('reports').update({ status:'resolved' }).eq('id', id);
+      loadReports();
+    }
+  } else if(e.target.classList.contains('remove')){
+    if(confirm('Remove this listing?')){
+      await supabase.from('listings').update({ is_active:false }).eq('id', id);
+      await supabase.from('reports').update({ status:'resolved' }).eq('listing_id', id);
+      loadReports();
+    }
+  }
+});

--- a/sql/extended_schema.sql
+++ b/sql/extended_schema.sql
@@ -57,3 +57,8 @@ create table if not exists public.comment_reports (
   reason text,
   created_at timestamptz default now()
 );
+
+-- Additional columns for admin dashboard
+alter table public.listings add column if not exists category text;
+alter table public.listings add column if not exists is_active boolean default true;
+alter table public.reports add column if not exists status text default 'open';


### PR DESCRIPTION
## Summary
- implement a new `admin-dashboard.html` page
- add `adminDashboard.js` and minimal CSS for charts and tables
- update SQL schema with new columns used by the dashboard
- document the new dashboard in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f00a8695483238e8723aba8856f12