### PR TITLE
Improve stats layout with accessible cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,22 +14,21 @@
     <link rel="stylesheet" href="css/styles.css">
     <style>
       .stats {
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: center;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
         gap: 1.5rem;
         margin-bottom: 1rem;
+        list-style: none;
+        padding: 0;
       }
       .stat-card {
         background: #fff;
         border-radius: 1rem;
         box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
         padding: 1.25rem;
-        width: 180px;
         display: flex;
         flex-direction: column;
         align-items: center;
-        justify-content: center;
         text-align: center;
         transition: transform 0.2s ease, box-shadow 0.2s ease;
       }
@@ -53,12 +52,7 @@
       }
       @media (max-width: 600px) {
         .stats {
-          flex-direction: column;
-          align-items: center;
-        }
-        .stat-card {
-          width: 100%;
-          max-width: 300px;
+          grid-template-columns: 1fr;
         }
       }
     </style>
@@ -98,22 +92,22 @@
         </section>
 <section class="services py-5 bg-light mb-5">
             <div class="container">
-                <div class="stats" id="summaryRow">
-                    <div class="stat-card">
-                        <div class="stat-icon">🔧</div>
-                        <div class="stat-number">120+</div>
-                        <div class="stat-label" data-i18n="total_services">Total Services</div>
-                    </div>
-                    <div class="stat-card">
-                        <div class="stat-icon">🏙️</div>
-                        <div class="stat-number">30+</div>
-                        <div class="stat-label" data-i18n="covered_cities">Covered Cities</div>
-                    </div>
-                    <div class="stat-card">
-                        <div class="stat-icon">📅</div>
-                        <div class="stat-number" data-i18n="updated_weekly">Updated Weekly</div>
-                    </div>
-                </div>
+                <ul class="stats" id="summaryRow" aria-label="Site summary">
+                    <li class="stat-card">
+                        <span class="stat-icon" aria-hidden="true">🔧</span>
+                        <h2 class="stat-number">120+</h2>
+                        <p class="stat-label" data-i18n="total_services">Total Services</p>
+                    </li>
+                    <li class="stat-card">
+                        <span class="stat-icon" aria-hidden="true">🏙️</span>
+                        <h2 class="stat-number">30+</h2>
+                        <p class="stat-label" data-i18n="covered_cities">Covered Cities</p>
+                    </li>
+                    <li class="stat-card">
+                        <span class="stat-icon" aria-hidden="true">📅</span>
+                        <h2 class="stat-number" data-i18n="updated_weekly">Updated Weekly</h2>
+                    </li>
+                </ul>
                 <div class="text-end mb-4">
                     <a href="submit.html" class="bg-blue-600 text-white px-3 py-1 rounded text-sm" data-i18n="submit_cta">Want your business listed? → Submit Now</a>
                 </div>


### PR DESCRIPTION
## Summary
- update styles for stat cards to use CSS grid and better spacing
- convert stats markup to an accessible `<ul>` list
- add semantic headings and hidden labels for icons

## Testing
- `tidy -quiet -errors index.html`

------
https://chatgpt.com/codex/tasks/task_e_684f06ebad308323971e68171a02b195