### PR TITLE
Add redesigned service details demo

### DIFF
--- a/service-details.html
+++ b/service-details.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Service Details - WedaKiriya.lk</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --bg: #f8fafd;
+      --primary: #2563eb;
+      --card-bg: #ffffff;
+      --text: #111827;
+      --muted: #6b7280;
+    }
+
+    body {
+      font-family: 'Inter', sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      margin: 0;
+      padding: 2rem 1rem;
+    }
+
+    .card {
+      background: var(--card-bg);
+      border-radius: 1rem;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+      max-width: 600px;
+      margin: 0 auto;
+      padding: 2rem;
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .icon {
+      font-size: 3rem;
+      width: 4rem;
+      height: 4rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 50%;
+      background: #eef2ff;
+      margin: 0 auto;
+    }
+
+    h1 {
+      font-size: 1.75rem;
+      text-align: center;
+      margin: 0;
+    }
+
+    .category {
+      text-align: center;
+      color: var(--muted);
+      margin-top: -0.5rem;
+    }
+
+    .contact {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      justify-content: center;
+    }
+
+    .btn {
+      display: inline-block;
+      text-decoration: none;
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.5rem;
+      font-weight: 600;
+      transition: background 0.2s ease, box-shadow 0.2s ease, color 0.2s ease;
+    }
+
+    .btn-primary {
+      background: var(--primary);
+      color: #fff;
+    }
+    .btn-primary:hover {
+      box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+    }
+
+    .btn-outline {
+      border: 1px solid var(--primary);
+      color: var(--primary);
+    }
+    .btn-outline:hover {
+      background: var(--primary);
+      color: #fff;
+    }
+
+    .share-buttons {
+      display: flex;
+      gap: 0.5rem;
+      justify-content: center;
+    }
+    .share-buttons button {
+      border: none;
+      background: #eef2ff;
+      padding: 0.5rem;
+      border-radius: 50%;
+      cursor: pointer;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+    .share-buttons button:hover {
+      background: var(--primary);
+      color: #fff;
+    }
+
+    .save-btn {
+      margin-left: auto;
+    }
+
+    .description {
+      line-height: 1.5;
+    }
+
+    .skeleton {
+      animation: pulse 1s infinite alternate;
+      background: #e5e7eb;
+      border-radius: 0.5rem;
+    }
+    @keyframes pulse {
+      from { opacity: 0.6; }
+      to { opacity: 1; }
+    }
+  </style>
+</head>
+<body>
+<div id="card" class="card" aria-live="polite">
+  <div id="loading">
+    <div class="skeleton" style="width: 60%; height: 2rem; margin: 0 auto 1rem;"></div>
+    <div class="skeleton" style="width: 40%; height: 1rem; margin: 0 auto 2rem;"></div>
+    <div class="skeleton" style="width: 100%; height: 6rem;"></div>
+  </div>
+</div>
+<script>
+const service = {
+  name: "ABC Tailors",
+  category: "Tailor",
+  city: "Colombo",
+  phone: "0771234567",
+  whatsapp: "0771234567",
+  description: "Expert tailoring services for men and women. Quick delivery.",
+  icon: "\u2702\uFE0F",
+  address: "123 Galle Road, Colombo",
+  website: "https://abctailors.lk"
+};
+
+function render(data){
+  const card = document.getElementById('card');
+  card.innerHTML = `
+    <div class="icon" aria-hidden="true">${data.icon || '📌'}</div>
+    <h1>${data.name}</h1>
+    <p class="category">${data.category} • ${data.city}</p>
+    <div class="contact">
+      <a href="tel:${data.phone}" class="btn btn-outline" aria-label="Call ${data.phone}">📞 ${data.phone}</a>
+      <a href="https://wa.me/94${data.whatsapp.substring(1)}" target="_blank" class="btn btn-primary" aria-label="WhatsApp">WhatsApp</a>
+      <button id="saveBtn" class="btn btn-outline save-btn" aria-label="Save listing">Save</button>
+    </div>
+    <div class="share-buttons" aria-label="Share options">
+      <button id="fbShare" aria-label="Share on Facebook">f</button>
+      <button id="twShare" aria-label="Share on X">x</button>
+      <button id="waShare" aria-label="Share on WhatsApp">wa</button>
+      <button id="copyShare" aria-label="Copy link">⧉</button>
+    </div>
+    <p class="description">${data.description}</p>
+    <p><strong>Address:</strong> ${data.address}</p>
+    <p><a href="${data.website}" target="_blank" rel="noopener">${data.website}</a></p>
+  `;
+
+  const saveBtn = document.getElementById('saveBtn');
+  const key = 'fav-' + data.name;
+  if(localStorage.getItem(key)) saveBtn.textContent = 'Saved';
+  saveBtn.addEventListener('click', () => {
+    localStorage.setItem(key, JSON.stringify(data));
+    saveBtn.textContent = 'Saved';
+  });
+
+  const url = encodeURIComponent(location.href);
+  document.getElementById('fbShare').onclick = () => window.open(`https://www.facebook.com/sharer/sharer.php?u=${url}`, '_blank');
+  document.getElementById('twShare').onclick = () => window.open(`https://twitter.com/intent/tweet?url=${url}&text=${encodeURIComponent(data.name)}`, '_blank');
+  document.getElementById('waShare').onclick = () => window.open(`https://wa.me/?text=${encodeURIComponent(data.name + ' ' + location.href)}`, '_blank');
+  document.getElementById('copyShare').onclick = async () => {
+    try { await navigator.clipboard.writeText(location.href); } catch(e){}
+    const btn = document.getElementById('copyShare');
+    btn.textContent = '✓';
+    setTimeout(()=>btn.textContent='⧉',1500);
+  };
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  setTimeout(() => render(service), 600);
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- demo of a responsive, accessible service details layout
- includes share buttons, save to localStorage and skeleton loader

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f09509d2c8323a3d828e441fcbbdc